### PR TITLE
Make docker image compile for other platforms, merge dockerfiles

### DIFF
--- a/.github/workflows/app-docker.yml
+++ b/.github/workflows/app-docker.yml
@@ -13,5 +13,6 @@ jobs:
       username: "ajayyy"
       folder: "."
       file: "Dockerfile"
+      target: "app"
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,6 +15,9 @@ on:
       file:
         required: true
         type: string
+      target:
+        required: true
+        type: string
     secrets:
       GH_TOKEN:
         required: true
@@ -49,3 +52,4 @@ jobs:
           file: ${{ inputs.file }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          target: ${{ inputs.target }}

--- a/.github/workflows/worker-docker.yml
+++ b/.github/workflows/worker-docker.yml
@@ -13,5 +13,6 @@ jobs:
       username: "ajayyy"
       folder: "."
       file: "Dockerfile-worker"
+      target: "worker"
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,22 @@
-FROM python:3.11-alpine
+FROM python:3.11-alpine AS builder
+RUN apk add --no-cache ffmpeg gcc musl-dev libffi-dev
+COPY requirements.txt /
+RUN mkdir /wheels
+WORKDIR /wheels
+RUN pip wheel -r /requirements.txt
+
+FROM python:3.11-alpine AS base
+COPY --from=builder /wheels /wheels
+RUN pip install /wheels/* && rm -rf /wheels
 RUN apk add --no-cache ffmpeg
 COPY . /app
 WORKDIR /app
-RUN pip install -r requirements.txt
+
+FROM base AS app
 EXPOSE 3000
 CMD ["python", "app.py"]
+
+FROM base AS worker
+EXPOSE 3001
+CMD ["python", "worker.py"]
+

--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -1,7 +1,0 @@
-FROM python:3.11-alpine
-RUN apk add --no-cache ffmpeg
-COPY . /app
-WORKDIR /app
-RUN pip install -r requirements.txt
-EXPOSE 3001
-CMD ["python", "worker.py"]


### PR DESCRIPTION
The builder step is mostly for archs such as arm64, where cffi requires a compiler & headers to compile successfully.
It handles downloading & compiling python packages, then exports them into wheels for output images to install.
My builds of the new images seem to be ~20MB smaller than the current ones.
While at it, I've merged the two Dockerfiles into one - Images can be built with `docker build --target app -t thumbnail-cache .` and `docker build --target worker -t thumbnail-cache-worker .`
Both images now base off of a "base" image, and just apply the tiny expose/cmd changes. This should make them use the same layers, so building the worker image after having built the main one is literally free. Not sure if workflow-built images will have the same effect.
Workflow changes included, but not tested.