### PR TITLE
Replace python-ffmpeg with own implementation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,10 +19,8 @@ py==1.11.0
 pycparser==2.21
 pycryptodomex==3.17
 pydantic==1.10.7
-pyee==9.1.0
 pytest==7.3.1
 pytest-asyncio==0.21.0
-python-ffmpeg==2.0.4
 PyYAML==6.0
 redis==4.5.5
 requests==2.30.0

--- a/utils/ffmpeg.py
+++ b/utils/ffmpeg.py
@@ -1,0 +1,35 @@
+import subprocess
+import shutil
+
+TimeoutExpired = subprocess.TimeoutExpired
+ffmpeg_path = shutil.which("ffmpeg")
+if ffmpeg_path is None:
+    raise RuntimeError("ffmpeg binary couldn't be found on the PATH")
+
+
+class FFmpegError(Exception):
+    exit_code: int
+
+    def __init__(self, exit_code: int):
+        super().__init__(f"FFmpeg exited with exit code {exit_code}")
+        self.exit_code = exit_code
+
+
+def run_ffmpeg(*args: str, timeout: float | None = None):
+    """
+    Runs FFmpeg. Any output is /dev/null'd.
+
+    Raises subprocess.TimeoutExpired on timeout. (reexported here for convenience)
+    Raises FFmpegError if FFmpeg exits with a non-zero code.
+    """
+    proc = subprocess.run(
+        [ffmpeg_path, *args],
+        shell=False,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=timeout,
+    )
+
+    if proc.returncode != 0:
+        raise FFmpegError(proc.returncode)


### PR DESCRIPTION
python-ffmpeg didn't play well with rq's timeout exceptions, causing deadlocks.

This PR replaces python-ffmpeg with a much simpler function that doesn't cause deadlocks on interruption, at a cost of having to think more about ffmpeg's input arguments.
It raises `FFmpegError` if ffmpeg exits with a non-zero exit code.
It also passes on the `TimeoutExpired` error that it may get from `subprocess` if ffmpeg times out. This causes rq's logging to throw a weird error if uncaught, but doesn't cause the worker to die or become unusable.

I've tested this PR by running about 200 videos through it - I encountered no deadlocks or dead workers.