### PR TITLE
Encode title as JSON to bypass ASCII header limitations

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,5 @@
+import json
+
 from fastapi import FastAPI, HTTPException, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
@@ -99,10 +101,7 @@ async def handle_thumbnail_response(video_id: str, time: float | None, title: st
     response.headers["X-Timestamp"] = str(thumbnail.time)
     response.headers["Cache-Control"] = "public, max-age=3600"
     if thumbnail.title is not None:
-        try:
-            response.headers["X-Title"] = thumbnail.title.strip()
-        except UnicodeEncodeError:
-            pass
+        response.headers["X-Title"] = json.dumps(thumbnail.title.strip(), ensure_ascii=True)
 
     return Response(content=thumbnail.image, media_type="image/webp", headers=response.headers)
 

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -1,4 +1,5 @@
 from multiprocessing import Process
+import json
 import os
 import shutil
 import time
@@ -91,7 +92,7 @@ async def load_and_verify_request(video_id: str, time: float, title: str | None 
     assert test_result.headers["X-Timestamp"] == str(time)
 
     if title is not None and not send_title:
-        assert test_result.headers["X-Title"] == title
+        assert test_result.headers["X-Title"] == json.dumps(title, ensure_ascii=True)
 
 
 async def load_and_verify_thumbnail(video_id: str, time: float, title: str | None = None) -> None:


### PR DESCRIPTION
This PR is an attempt to fix #3 by encoding all titles in the headers as JSON.
This should not be merged until ajayyy/DeArrow#100 has been merged and released.
The client-side PR is backwards-compatible, this one is not.