### PR TITLE
add option to disable worker name randomization

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -48,6 +48,7 @@ class Config(TypedDict):
     front_auth: str | None
     floatie_auth: str | None
     debug: bool
+    randomize_worker_names: bool
 
 
 config: Config = yaml.safe_load(open("config.yaml" if not in_test() else "tests/test_config.yaml"))
@@ -56,3 +57,5 @@ if "proxy_url" not in config:
     config["proxy_url"] = None
 if "proxy_token" not in config:
     config["proxy_token"] = None
+if "randomize_worker_names" not in config:
+    config["randomize_worker_names"] = True

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -2,6 +2,8 @@ import math
 from socket import gethostname
 import random
 
+from .config import config
+
 
 def random_hex(length: int) -> str:
     byte_count = math.ceil(length / 2)
@@ -9,4 +11,6 @@ def random_hex(length: int) -> str:
 
 
 def generate_worker_name() -> str:
-    return f"{gethostname()}-{random_hex(4)}"
+    if config["randomize_worker_names"]:
+        return f"{gethostname()}-{random_hex(4)}"
+    return gethostname()


### PR DESCRIPTION
this option is safe to enable if it is guaranteed that each worker will be running on a system/container with a unique hostname
makes grafana & prometheus less mad about the amount of unique label values